### PR TITLE
Fix parsing of local export target

### DIFF
--- a/src/rgl/config.rs
+++ b/src/rgl/config.rs
@@ -48,7 +48,7 @@ impl Config {
         profiles.insert(
             "build".to_owned(),
             Profile {
-                export: Export::Local(LocalExport),
+                export: Export::Local(LocalExport {}),
                 filters: vec![FilterRunner::ProfileFilter {
                     profile_name: "default".to_owned(),
                 }],

--- a/src/rgl/export.rs
+++ b/src/rgl/export.rs
@@ -52,7 +52,7 @@ impl ExportPaths for DevelopmentExport {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct LocalExport;
+pub struct LocalExport {}
 
 impl ExportPaths for LocalExport {
     fn get_paths(&self, name: &str) -> Result<(PathBuf, PathBuf)> {


### PR DESCRIPTION
rgl currently fails to parse local exports like this...
```jsonc
"profiles": {
    "build": {
        "export": {
            "readOnly": false,
            "target": "local"
        },
        "filters": [ /* ... */ ]
    }
}
```
I'm not sure if there is a better way to fix this, we should also consider modifying the parsing to forbid unknown fields & parse things like `rp_name`, `bp_name` and `readOnly`