### PR TITLE
Add "preview_gdk" target

### DIFF
--- a/src/rgl/minecraft.rs
+++ b/src/rgl/minecraft.rs
@@ -76,6 +76,8 @@ fn find_gdk_preview_mojang_dir() -> Result<PathBuf> {
     let localappdata = env::var("AppData")?;
     Ok(PathBuf::from(localappdata)
         .join("Minecraft Bedrock Preview")
+        .join("Users")
+        .join("Shared")
         .join("games")
         .join("com.mojang"))
 }

--- a/src/rgl/minecraft.rs
+++ b/src/rgl/minecraft.rs
@@ -10,6 +10,8 @@ use std::path::PathBuf;
 pub enum MinecraftBuild {
     Standard,
     Preview,
+    #[allow(non_camel_case_types)]
+    Preview_GDK,
     Education,
 }
 
@@ -69,6 +71,20 @@ fn find_preview_mojang_dir() -> Result<PathBuf> {
         .join("com.mojang"))
 }
 
+#[cfg(target_os = "windows")]
+fn find_gdk_preview_mojang_dir() -> Result<PathBuf> {
+    let localappdata = env::var("AppData")?;
+    Ok(PathBuf::from(localappdata)
+        .join("Minecraft Bedrock Preview")
+        .join("games")
+        .join("com.mojang"))
+}
+
+#[cfg(unix)]
+fn find_gdk_preview_mojang_dir() -> Result<PathBuf> {
+    mojang_dir()
+}
+
 #[cfg(unix)]
 fn find_education_mojang_dir() -> Result<PathBuf> {
     mojang_dir()
@@ -88,6 +104,7 @@ pub fn find_mojang_dir(build: Option<&MinecraftBuild>) -> Result<PathBuf> {
         Some(MinecraftBuild::Standard) | None => find_standard_mojang_dir(),
         Some(MinecraftBuild::Preview) => find_preview_mojang_dir(),
         Some(MinecraftBuild::Education) => find_education_mojang_dir(),
+        Some(MinecraftBuild::Preview_GDK) => find_gdk_preview_mojang_dir(),
     }
 }
 


### PR DESCRIPTION
This adds a `preview_gdk` target to rgl to support the new GDK builds of preview. I kinda just made up a new target name since the regular regolith does not support this yet either, but I needed to support it myself and may as well PR it in just incase.

Lemme know if you have any changes, I did have to allow a non camel case name to have it be `preview_gdk` instead of `previewgdk` since I thought that was nicer